### PR TITLE
Escape oauth_signature in url query string

### DIFF
--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -35,7 +35,7 @@ module WooCommerce
       params["oauth_nonce"] = Digest::SHA1.hexdigest("#{Time.new.to_i + rand(99999)}")
       params["oauth_signature_method"] = "HMAC-SHA256"
       params["oauth_timestamp"] = Time.new.to_i
-      params["oauth_signature"] = generate_oauth_signature(params, url)
+      params["oauth_signature"] = CGI::escape(generate_oauth_signature(params, url))
 
       query_string = URI::encode(params.map{|key, value| "#{key}=#{value}"}.join("&"))
 


### PR DESCRIPTION
The oauth_signature can contain reserved characters (eg '+'). These characters must be escaped in order for wooCommerce to use the same signature when authenticating the request.