### PR TITLE
Adding port to the url

### DIFF
--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -28,7 +28,7 @@ module WooCommerce
           params[key] = value[0]
         end
 
-        url = "#{parsed_url.scheme}://#{parsed_url.host}#{parsed_url.path}"
+        url = "#{parsed_url.scheme}://#{parsed_url.host}:#{parsed_url.port}#{parsed_url.path}"
       end
 
       params["oauth_consumer_key"] = @consumer_key


### PR DESCRIPTION
When using an url like `http://myhost:8080/wc-api/v3/products?page:2` it was removing the `8080` port from the url, producing a failed request.