### PR TITLE
Allow client to specify the signature method

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -19,6 +19,7 @@ module WooCommerce
 
       @version = args[:version]
       @verify_ssl = args[:verify_ssl] == true
+      @signature_method = args[:signature_method]
 
       # Internal args
       @is_ssl = @url.start_with? "https"
@@ -80,7 +81,7 @@ module WooCommerce
 
     # Internal: Requests default options.
     #
-    # method   - A String maning the request method
+    # method   - A String naming the request method
     # endpoint - A String naming the request endpoint.
     # data     - The Hash data for the request.
     #
@@ -106,8 +107,7 @@ module WooCommerce
           }
         })
       else
-        oauth = WooCommerce::OAuth.new url, method, @version, @consumer_key, @consumer_secret
-        url = oauth.get_oauth_url
+        url = oauth_url(url, method)
       end
 
       if data
@@ -119,5 +119,20 @@ module WooCommerce
       HTTParty.send method, url, options
     end
 
+    # Internal: Generates an oauth url given current settings
+    #
+    # url    - A String naming the current request url
+    # method - The HTTP verb of the request
+    #
+    # Returns a url to be used for the query.
+    def oauth_url(url, method)
+      oauth = WooCommerce::OAuth.new(url,
+                                     method,
+                                     @version,
+                                     @consumer_key,
+                                     @consumer_secret,
+                                     @signature_method)
+      oauth.get_oauth_url
+    end
   end
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -130,4 +130,11 @@ class WooCommerceAPITest < Minitest::Test
     assert_equal 202, response.code
     assert_equal '{"message":"Permanently deleted product"}', response.to_json
   end
+
+  def test_invalid_signature_method
+    assert_raises WooCommerce::OAuth::InvalidSignatureMethodError do 
+      client = WooCommerce::API.new("http://dev.test/", "user", "pass", signature_method: 'GARBAGE')
+      client.get 'products'
+    end
+  end
 end


### PR DESCRIPTION
I would like to be able to use SHA1 for the signature (it's slightly faster with no known security compromises). Also, the woo api says that it supports both SHA256 and SHA1 so why not have the gem support both?

Anyhow, I tried to match the format as close as possible. Thanks!