### PR TITLE
Reduce chance of nonce collisions

### DIFF
--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -36,7 +36,8 @@ module WooCommerce
       end
 
       params["oauth_consumer_key"] = @consumer_key
-      params["oauth_nonce"] = Digest::SHA1.hexdigest("#{Time.new.to_i + rand(99999)}")
+      nonce_lifetime = 15 * 60 # Woocommerce keeps nonces for 15 minutes
+      params["oauth_nonce"] = Digest::SHA1.hexdigest((Time.new.to_f % nonce_lifetime + (Process.pid * nonce_lifetime)).to_s)
       params["oauth_signature_method"] = @signature_method
       params["oauth_timestamp"] = Time.new.to_i
       params["oauth_signature"] = CGI::escape(generate_oauth_signature(params, url))


### PR DESCRIPTION
Woocommerce only requires nonces only need to be unique within a 15 minute window. We use the modulo of the floating point time so that our nonces cycle every 15 minutes and add (PID * 15 mins) to ensure that no process on the same machine is using the same range of numbers. The only way a collision can occur is if processes on different machines have the same PID and start the request at the same time (within microseconds).