### PR TITLE
Support data params for GET and DELETE

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -28,6 +28,7 @@ module WooCommerce
     # Public: GET requests.
     #
     # endpoint - A String naming the request endpoint.
+    # data     - The Hash data for the request.
     #
     # Returns the request Hash.
     def get endpoint, data = nil
@@ -57,6 +58,7 @@ module WooCommerce
     # Public: DELETE requests.
     #
     # endpoint - A String naming the request endpoint.
+    # data     - The Hash data for the request.
     #
     # Returns the request Hash.
     def delete endpoint, data = nil
@@ -65,6 +67,12 @@ module WooCommerce
 
     protected
 
+    # Internal: Appends data as query params onto an endpoint
+    #
+    # endpoint - A String naming the request endpoint.
+    # data     - A hash of data to flatten and append
+    #
+    # Returns an endpoint string with the data appended
     def add_query_params(endpoint, data)
       return endpoint if data.nil? || data.empty?
       endpoint += '?' unless endpoint.include? '?'
@@ -75,6 +83,7 @@ module WooCommerce
     # Internal: Get URL for requests
     #
     # endpoint - A String naming the request endpoint.
+    # method   - The method used in the url (for oauth querys)
     #
     # Returns the endpoint String.
     def get_url endpoint, method
@@ -133,6 +142,11 @@ module WooCommerce
       oauth.get_oauth_url
     end
 
+    # Internal: Flattens a hash into an array of query relations
+    #
+    # hash - A hash to flatten
+    #
+    # Returns an array full of key value paired strings
     def flatten_hash(hash)
       hash.flat_map do |key, value|
         case value

--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -111,6 +111,11 @@ module WooCommerce
           "Accept" => "application/json"
         }
       }
+      if @is_ssl
+        options.merge!(basic_auth: {
+                         username: @consumer_key,
+                         password: @consumer_secret })
+      end
       options.merge!(body: data.to_json) if data
       HTTParty.send(method, url, options)
     end
@@ -121,9 +126,7 @@ module WooCommerce
     #
     # Returns a url to be used for the query.
     def ssl_url(url)
-      add_query_params(url,
-                       consumer_key: @consumer_key,
-                       consumer_secret: @consumer_secret)
+      url
     end
 
     # Internal: Generates an oauth url given current settings

--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -31,6 +31,7 @@ module WooCommerce
         CGI::parse(parsed_url.query).each do |key, value|
           params[key] = value[0]
         end
+        params = Hash[params.sort]
 
         url = "#{parsed_url.scheme}://#{parsed_url.host}#{parsed_url.path}"
       end

--- a/test/test.rb
+++ b/test/test.rb
@@ -20,7 +20,7 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_get
-    FakeWeb.register_uri(:get, "https://dev.test/wc-api/v3/customers?consumer_key=user&consumer_secret=pass",
+    FakeWeb.register_uri(:get, "https://user:pass@dev.test/wc-api/v3/customers",
       body: '{"customers":[]}',
       content_type: "application/json"
     )
@@ -40,7 +40,7 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_post
-    FakeWeb.register_uri(:post, "https://dev.test/wc-api/v3/products?consumer_key=user&consumer_secret=pass",
+    FakeWeb.register_uri(:post, "https://user:pass@dev.test/wc-api/v3/products",
       body: '{"products":[]}',
       content_type: "application/json",
       status: ["201", "Created"]
@@ -74,7 +74,7 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_put
-    FakeWeb.register_uri(:put, "https://dev.test/wc-api/v3/products/1234?consumer_key=user&consumer_secret=pass",
+    FakeWeb.register_uri(:put, "https://user:pass@dev.test/wc-api/v3/products/1234",
       body: '{"customers":[]}',
       content_type: "application/json"
     )
@@ -106,7 +106,7 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_delete
-    FakeWeb.register_uri(:delete, "https://dev.test/wc-api/v3/products/1234?force=true&consumer_key=user&consumer_secret=pass",
+    FakeWeb.register_uri(:delete, "https://user:pass@dev.test/wc-api/v3/products/1234?force=true",
       body: '{"message":"Permanently deleted product"}',
       content_type: "application/json",
       status: ["202", "Accepted"]
@@ -118,8 +118,8 @@ class WooCommerceAPITest < Minitest::Test
     assert_equal '{"message":"Permanently deleted product"}', response.to_json
   end
 
-  def test_basic_auth_delete_with_data_params
-    FakeWeb.register_uri(:delete, "https://dev.test/wc-api/v3/products/1234?force=true&consumer_key=user&consumer_secret=pass",
+  def test_basic_auth_delete_params
+    FakeWeb.register_uri(:delete, "https://user:pass@dev.test/wc-api/v3/products/1234?force=true",
       body: '{"message":"Permanently deleted product"}',
       content_type: "application/json",
       status: ["202", "Accepted"]

--- a/test/test.rb
+++ b/test/test.rb
@@ -39,6 +39,16 @@ class WooCommerceAPITest < Minitest::Test
     assert_equal 200, response.code
   end
 
+  def test_oauth_get_puts_data_in_alpha_order
+    FakeWeb.register_uri(:get, /http:\/\/dev\.test\/wc-api\/v3\/customers\?abc=123&oauth_consumer_key=user&oauth_d=456&oauth_nonce=(.*)&(.*)oauth_signature_method=HMAC-SHA256&oauth_timestamp=(.*)&xyz=789/,
+      body: '{"customers":[]}',
+      content_type: "application/json"
+    )
+    response = @oauth.get "customers", abc: '123', oauth_d: '456', xyz: '789'
+
+    assert_equal 200, response.code
+  end
+
   def test_basic_auth_post
     FakeWeb.register_uri(:post, "https://user:pass@dev.test/wc-api/v3/products",
       body: '{"products":[]}',

--- a/test/test.rb
+++ b/test/test.rb
@@ -20,9 +20,9 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_get
-    FakeWeb.register_uri(:get, "https://user:pass@dev.test/wc-api/v3/customers",
-      :body => '{"customers":[]}',
-      :content_type => "application/json"
+    FakeWeb.register_uri(:get, "https://dev.test/wc-api/v3/customers?consumer_key=user&consumer_secret=pass",
+      body: '{"customers":[]}',
+      content_type: "application/json"
     )
     response = @basic_auth.get "customers"
 
@@ -31,8 +31,8 @@ class WooCommerceAPITest < Minitest::Test
 
   def test_oauth_get
     FakeWeb.register_uri(:get, /http:\/\/dev\.test\/wc-api\/v3\/customers\?oauth_consumer_key=user&oauth_nonce=(.*)&(.*)oauth_signature_method=HMAC-SHA256&oauth_timestamp=(.*)/,
-      :body => '{"customers":[]}',
-      :content_type => "application/json"
+      body: '{"customers":[]}',
+      content_type: "application/json"
     )
     response = @oauth.get "customers"
 
@@ -40,10 +40,10 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_post
-    FakeWeb.register_uri(:post, "https://user:pass@dev.test/wc-api/v3/products",
-      :body => '{"products":[]}',
-      :content_type => "application/json",
-      :status => ["201", "Created"]
+    FakeWeb.register_uri(:post, "https://dev.test/wc-api/v3/products?consumer_key=user&consumer_secret=pass",
+      body: '{"products":[]}',
+      content_type: "application/json",
+      status: ["201", "Created"]
     )
 
     data = {
@@ -58,9 +58,9 @@ class WooCommerceAPITest < Minitest::Test
 
   def test_oauth_post
     FakeWeb.register_uri(:post, /http:\/\/dev\.test\/wc-api\/v3\/products\?oauth_consumer_key=user&oauth_nonce=(.*)&(.*)oauth_signature_method=HMAC-SHA256&oauth_timestamp=(.*)/,
-      :body => '{"products":[]}',
-      :content_type => "application/json",
-      :status => ["201", "Created"]
+      body: '{"products":[]}',
+      content_type: "application/json",
+      status: ["201", "Created"]
     )
 
     data = {
@@ -74,9 +74,9 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_put
-    FakeWeb.register_uri(:put, "https://user:pass@dev.test/wc-api/v3/products/1234",
-      :body => '{"customers":[]}',
-      :content_type => "application/json"
+    FakeWeb.register_uri(:put, "https://dev.test/wc-api/v3/products/1234?consumer_key=user&consumer_secret=pass",
+      body: '{"customers":[]}',
+      content_type: "application/json"
     )
 
     data = {
@@ -91,8 +91,8 @@ class WooCommerceAPITest < Minitest::Test
 
   def test_oauth_put
     FakeWeb.register_uri(:put, /http:\/\/dev\.test\/wc-api\/v3\/products\?oauth_consumer_key=user&oauth_nonce=(.*)&(.*)oauth_signature_method=HMAC-SHA256&oauth_timestamp=(.*)/,
-      :body => '{"products":[]}',
-      :content_type => "application/json"
+      body: '{"products":[]}',
+      content_type: "application/json"
     )
 
     data = {
@@ -106,10 +106,10 @@ class WooCommerceAPITest < Minitest::Test
   end
 
   def test_basic_auth_delete
-    FakeWeb.register_uri(:delete, "https://user:pass@dev.test/wc-api/v3/products/1234?force=true",
-      :body => '{"message":"Permanently deleted product"}',
-      :content_type => "application/json",
-      :status => ["202", "Accepted"]
+    FakeWeb.register_uri(:delete, "https://dev.test/wc-api/v3/products/1234?force=true&consumer_key=user&consumer_secret=pass",
+      body: '{"message":"Permanently deleted product"}',
+      content_type: "application/json",
+      status: ["202", "Accepted"]
     )
 
     response = @basic_auth.delete "products/1234?force=true"
@@ -118,17 +118,35 @@ class WooCommerceAPITest < Minitest::Test
     assert_equal '{"message":"Permanently deleted product"}', response.to_json
   end
 
+  def test_basic_auth_delete_with_data_params
+    FakeWeb.register_uri(:delete, "https://dev.test/wc-api/v3/products/1234?force=true&consumer_key=user&consumer_secret=pass",
+      body: '{"message":"Permanently deleted product"}',
+      content_type: "application/json",
+      status: ["202", "Accepted"]
+    )
+
+    response = @basic_auth.delete "products/1234", force: true
+
+    assert_equal 202, response.code
+    assert_equal '{"message":"Permanently deleted product"}', response.to_json
+  end
+
   def test_oauth_put
     FakeWeb.register_uri(:delete, /http:\/\/dev\.test\/wc-api\/v3\/products\/1234\?force=true&oauth_consumer_key=user&oauth_nonce=(.*)&(.*)oauth_signature_method=HMAC-SHA256&oauth_timestamp=(.*)/,
-      :body => '{"message":"Permanently deleted product"}',
-      :content_type => "application/json",
-      :status => ["202", "Accepted"]
+      body: '{"message":"Permanently deleted product"}',
+      content_type: "application/json",
+      status: ["202", "Accepted"]
     )
 
     response = @oauth.delete "products/1234?force=true"
 
     assert_equal 202, response.code
     assert_equal '{"message":"Permanently deleted product"}', response.to_json
+  end
+
+  def test_adding_query_params
+    url = @oauth.send(:add_query_params, 'foo.com', filter: { sku: '123' }, order: 'created_at')
+    assert_equal url, URI.encode('foo.com?filter[sku]=123&order=created_at')
   end
 
   def test_invalid_signature_method


### PR DESCRIPTION
@claudiosmweb 

This enables passing data into the get and delete routes (which would be needed for filters and forces) instead of using the query params as strings.

This:
```ruby
client.delete('products/1', force: true)
```

rather than this:
```ruby
client.delete('products/1?force=true)
```

For filters it's even more obvious why this form is better:

```ruby
client.get('products', filter: { sku: '123' })
```