### PR TITLE
Encode spaces in query string for oauth signature

### DIFF
--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -94,7 +94,7 @@ module WooCommerce
     #
     # Returns the encoded String.
     def encode_param text
-      CGI::escape(text).gsub("%", "%25")
+      CGI::escape(text).gsub('+', '%20').gsub("%", "%25")
     end
   end
 end


### PR DESCRIPTION
CGI::escape encodes a space as '+' but we need it as %20

Fixes #14 