### PR TITLE
only set request body if data parameter is filled

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -123,7 +123,7 @@ module WooCommerce
           password: @consumer_secret
         })
       end
-      options.merge!(body: data.to_json) if data
+      options.merge!(body: data.to_json) if data && !data.empty?  
       HTTParty.send(method, url, options)
     end
 


### PR DESCRIPTION
When accessing a store (version 2.4.10, API version 3, http protocol) with URL `http://.../wc-api/v3/products/count` it always failed with `oauth_consumer_key parameter is missing`.When not setting the body the requests work. It seems sensible to skip the body as maybe the receiving end misinterprets it.