### PR TITLE
Dont set empty JSON body on get requests

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -123,7 +123,7 @@ module WooCommerce
           password: @consumer_secret
         })
       end
-      options.merge!(body: data.to_json) if !data.empty?
+      options.merge!(body: data.to_json) if method != :get && !data.empty?
 
       HTTParty.send(method, url, options)
     end


### PR DESCRIPTION
Not sure if it's just my host but when performing a `GET` request with a JSON body like "{}" I get redirected to my domain root.
Not sending any body with a GET request solves this. This might be a HTTParty problem though since sending a body in GET requests perhaps shouldn't be accepted?

Using HTTParty 0.13.7