### PR TITLE
HTTParty debug mode + Option to force consumer key and secret on url parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ woocommerce = WooCommerce::API.new(
 | `version`          | `String` | no       | API version, default is `v3`                                                                                 |
 | `verify_ssl`       | `Bool`   | no       | Verify SSL when connect, use this option as `false` when need to test with self-signed certificates          |
 | `signature_method` | `String` | no       | Signature method used for oAuth requests, works with `HMAC-SHA1` and `HMAC-SHA256`, default is `HMAC-SHA256` |
+| `force_auth_params`| `Bool`   | no       | Force the consumer key and secret to the url parameters                                                      |
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ woocommerce = WooCommerce::API.new(
 | `verify_ssl`       | `Bool`   | no       | Verify SSL when connect, use this option as `false` when need to test with self-signed certificates          |
 | `signature_method` | `String` | no       | Signature method used for oAuth requests, works with `HMAC-SHA1` and `HMAC-SHA256`, default is `HMAC-SHA256` |
 | `force_auth_params`| `Bool`   | no       | Force the consumer key and secret to the url parameters                                                      |
+| `debug_mode`       | `Bool`   | no       | Enables HTTParty debug mode                                                                                  |
 
 ## Methods
 

--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -21,6 +21,7 @@ module WooCommerce
       }
       args = defaults.merge(args)
 
+      @force_auth_params = args[:force_auth_params]
       @version = args[:version]
       @verify_ssl = args[:verify_ssl] == true
       @signature_method = args[:signature_method]
@@ -123,6 +124,14 @@ module WooCommerce
           password: @consumer_secret
         })
       end
+
+      if @force_auth_params
+        options.merge!(query: {
+          username: @consumer_key,
+          password: @consumer_secret
+        })
+      end
+
       options.merge!(body: data.to_json) if !data.empty?
 
       HTTParty.send(method, url, options)

--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -21,6 +21,7 @@ module WooCommerce
       }
       args = defaults.merge(args)
 
+      @debug_mode = args[:debug_mode]
       @force_auth_params = args[:force_auth_params]
       @version = args[:version]
       @verify_ssl = args[:verify_ssl] == true
@@ -125,10 +126,12 @@ module WooCommerce
         })
       end
 
+      options.merge!(debug_output: $stdout) if @debug_mode
+
       if @force_auth_params
         options.merge!(query: {
-          username: @consumer_key,
-          password: @consumer_secret
+          consumer_key: @consumer_key,
+          consumer_secret: @consumer_secret
         })
       end
 


### PR DESCRIPTION
We have a few customer servers that reject both OAuth and Basic Auth, I think PHP might be doing something funky with the headers.

This pull request allows for the option of adding these to the parameters