### PR TITLE
allow headers option

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -132,11 +132,12 @@ module WooCommerce
       options = options.merge(@httparty_args)
 
       # Set headers.
-      options[:headers] = {
+      default_headers = {
         "User-Agent" => "WooCommerce API Client-Ruby/#{WooCommerce::VERSION}",
         "Accept" => "application/json"
       }
-      options[:headers]["Content-Type"] = "application/json;charset=utf-8" if !data.empty?
+      options[:headers] = default_headers.merge(options[:headers] || {})
+      options[:headers]["Content-Type"] ||= "application/json;charset=utf-8" if !data.empty?
 
       # Set basic authentication.
       if @is_ssl


### PR DESCRIPTION
We wanted to set a custom `User-Agent` header for our API calls and noticed that setting custom headers of any kind was impossible currently. 

Updates to honor a `headers` hash to be passed in along with the other `httparty_args`.