### PR TITLE
replace deprecated URI.encode

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -97,7 +97,7 @@ module WooCommerce
 
       endpoint += "?" unless endpoint.include? "?"
       endpoint += "&" unless endpoint.end_with? "?"
-      endpoint + URI.encode(flatten_hash(data).join("&"))
+      endpoint + URI.encode_www_form(flatten_hash(data))
     end
 
     # Internal: Get URL for requests
@@ -189,12 +189,12 @@ module WooCommerce
         case value
         when Hash
           value.map do |inner_key, inner_value|
-            "#{key}[#{inner_key}]=#{inner_value}"
+            ["#{key}[#{inner_key}]", "#{inner_value}"]
           end
         when Array
-          value.map { |inner_value| "#{key}[]=#{inner_value}" }
+          value.map { |inner_value| ["#{key}[]", "#{inner_value}"] }
         else
-          "#{key}=#{value}"
+          [["#{key}", "#{value}"]]
         end
       end
     end

--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -42,7 +42,7 @@ module WooCommerce
       params["oauth_timestamp"] = Time.new.to_i
       params["oauth_signature"] = CGI::escape(generate_oauth_signature(params, url))
 
-      query_string = URI::encode(params.map{|key, value| "#{key}=#{value}"}.join("&"))
+      query_string = URI.encode_www_form(params)
 
       "#{url}?#{query_string}"
     end

--- a/test/test.rb
+++ b/test/test.rb
@@ -155,7 +155,7 @@ class WooCommerceAPITest < Minitest::Test
 
   def test_adding_query_params
     url = @oauth.send(:add_query_params, 'foo.com', filter: { sku: '123' }, order: 'created_at')
-    assert_equal url, URI.encode('foo.com?filter[sku]=123&order=created_at')
+    assert_equal url, 'foo.com?filter%5Bsku%5D=123&order=created_at'
   end
 
   def test_invalid_signature_method


### PR DESCRIPTION
URI.encode has been deprecated in ruby and is displaying warnings in ruby 2.7