### PR TITLE
install required bundler on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ rvm:
  - 2.2.1
  - 2.3.0
  - ruby-head
+before_install:
+ - gem install bundler:1.12.5
 script: bundle exec rake test


### PR DESCRIPTION
Travis CI is currently failing on ruby 2.3.0 due to missing the required
version of bundler. Therefore we install the required version of bundler
before the install step runs 'bundle install'.