### PR TITLE
URI#encode deprecation

### DIFF
--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -42,7 +42,7 @@ module WooCommerce
       params["oauth_timestamp"] = Time.new.to_i
       params["oauth_signature"] = CGI::escape(generate_oauth_signature(params, url))
 
-      query_string = URI::encode(params.map{|key, value| "#{key}=#{value}"}.join("&"))
+      query_string = URI::encode_www_form(params)
 
       "#{url}?#{query_string}"
     end


### PR DESCRIPTION
Closes #57

URI, no longer supports `encode`, so, I am updating it to an existing method (`encode_www_form_component`).

Source: https://ruby-doc.org/stdlib-3.1.0/libdoc/uri/rdoc/URI.html

### Are you facing this issue? #57
You can replace the gem with this:
```
gem "woocommerce_api",
  git: "https://github.com/ricvillagrana/wc-api-ruby.git",
  branch: "patch-1"
```

And then run: `bundle update woocommerce_api`

**Remember to change it back when this PR is merged.**