### PR TITLE
Replacing deprecated URI::encode with URI.encode_www_form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "httparty"
-gem "json"
+gem "json", ">= 2.6.3"
 
 group :test do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     fakeweb (1.3.0)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    json (2.0.2)
+    json (2.6.3)
     minitest (5.10.1)
     multi_xml (0.6.0)
     rake (12.0.0)
@@ -15,7 +15,7 @@ PLATFORMS
 DEPENDENCIES
   fakeweb
   httparty
-  json
+  json (>= 2.6.3)
   minitest
   rake
 

--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -92,12 +92,17 @@ module WooCommerce
     # data     - A hash of data to flatten and append
     #
     # Returns an endpoint string with the data appended
-    def add_query_params endpoint, data
+    def add_query_params(endpoint, data)
       return endpoint if data.nil? || data.empty?
 
       endpoint += "?" unless endpoint.include? "?"
       endpoint += "&" unless endpoint.end_with? "?"
-      endpoint + URI.encode(flatten_hash(data).join("&"))
+
+      flattened_params = flatten_hash(data)
+
+      query_string = URI.encode_www_form(flattened_params)
+
+      endpoint + query_string
     end
 
     # Internal: Get URL for requests
@@ -184,17 +189,17 @@ module WooCommerce
     # hash - A hash to flatten
     #
     # Returns an array full of key value paired strings
-    def flatten_hash hash
+    def flatten_hash(hash)
       hash.flat_map do |key, value|
         case value
         when Hash
           value.map do |inner_key, inner_value|
-            "#{key}[#{inner_key}]=#{inner_value}"
+            ["#{key}[#{inner_key}]", inner_value]
           end
         when Array
-          value.map { |inner_value| "#{key}[]=#{inner_value}" }
+          value.map { |inner_value| ["#{key}[]", inner_value] }
         else
-          "#{key}=#{value}"
+          [[key, value]]
         end
       end
     end

--- a/lib/woocommerce_api/oauth.rb
+++ b/lib/woocommerce_api/oauth.rb
@@ -42,7 +42,7 @@ module WooCommerce
       params["oauth_timestamp"] = Time.new.to_i
       params["oauth_signature"] = CGI::escape(generate_oauth_signature(params, url))
 
-      query_string = URI::encode(params.map{|key, value| "#{key}=#{value}"}.join("&"))
+      query_string = URI.encode_www_form(params)
 
       "#{url}?#{query_string}"
     end

--- a/test/fakeweb_patch.rb
+++ b/test/fakeweb_patch.rb
@@ -1,0 +1,5 @@
+unless File.respond_to?(:exists?)
+  class << File
+    alias_method :exists?, :exist?
+  end
+end

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,4 +1,5 @@
 require "minitest/autorun"
+require_relative "fakeweb_patch"
 require "fakeweb"
 require "json"
 require "woocommerce_api"
@@ -155,11 +156,12 @@ class WooCommerceAPITest < Minitest::Test
 
   def test_adding_query_params
     url = @oauth.send(:add_query_params, 'foo.com', filter: { sku: '123' }, order: 'created_at')
-    assert_equal url, URI.encode('foo.com?filter[sku]=123&order=created_at')
+    expected = 'foo.com?filter%5Bsku%5D=123&order=created_at'
+    assert_equal expected, url
   end
 
   def test_invalid_signature_method
-    assert_raises WooCommerce::OAuth::InvalidSignatureMethodError do 
+    assert_raises WooCommerce::OAuth::InvalidSignatureMethodError do
       client = WooCommerce::API.new("http://dev.test/", "user", "pass", signature_method: 'GARBAGE')
       client.get 'products'
     end


### PR DESCRIPTION
This PR replaces the deprecated `URI.encode` method with the recommended alternative `URI.encode_www_form` to ensure compatibility with Ruby 3.3.0 and later versions. The `URI.encode` method was officially deprecated in Ruby 2.7 (December 2019) and has been completely removed in Ruby 3.3.0 (December 2023).